### PR TITLE
feat: The template file has ben created and configured

### DIFF
--- a/devtoy/settings.py
+++ b/devtoy/settings.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/4.0/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.0/ref/settings/
 """
+import os
 
 from pathlib import Path
 
@@ -54,7 +55,9 @@ ROOT_URLCONF = 'devtoy.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [
+            os.path.join(BASE_DIR, 'templates')
+        ],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [


### PR DESCRIPTION
The templates folder has been created and configured in the settings.py file. It was configured by writing `os.path.join(BASE_DIR, 'templates')` inside the 'DIRS' of the template configuration inside the setting.py file.("#")