### PR TITLE
feat: the static folder has been created and configured

### DIFF
--- a/devtoy/settings.py
+++ b/devtoy/settings.py
@@ -119,6 +119,9 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/4.0/howto/static-files/
 
 STATIC_URL = 'static/'
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, 'static')
+]
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.0/ref/settings/#default-auto-field


### PR DESCRIPTION
The static file has been created using the command `mkdir static` and configured in the settings.py file as `STATICFILES_DIRS = [
    os.path.join(BASE_DIR, 'static')
]`